### PR TITLE
ci: update node version in the CI actions to v18.20.2

### DIFF
--- a/.github/workflows/ci-builder.yml
+++ b/.github/workflows/ci-builder.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.16.1]
+        node-version: [18.20.2]
 
     steps:
       - name: Checkout files

--- a/.github/workflows/ci-viewer.yml
+++ b/.github/workflows/ci-viewer.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.16.1]
+        node-version: [18.20.2]
 
     steps:
       - name: Checkout files


### PR DESCRIPTION
Atualização da versão do Node para v18.20.2 por conta do Next.js exigir que a versão mínima do Node.js seja v18.17.