### PR TITLE
feat: http request to send mesage instead of make websocket connection

### DIFF
--- a/apps/builder/package.json
+++ b/apps/builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "builder",
-  "version": "1.0.18-c",
+  "version": "1.0.19",
   "license": "AGPL-3.0-or-later",
   "scripts": {
     "dev": "dotenv -e ./.env -e ../../.env -- next dev -p 3000 --experimental-https",

--- a/apps/viewer/package.json
+++ b/apps/viewer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "viewer",
   "license": "AGPL-3.0-or-later",
-  "version": "1.0.17-a",
+  "version": "1.0.18",
   "scripts": {
     "dev": "dotenv -e ./.env -e ../../.env  -- next dev -p 3001 --experimental-https",
     "build": "dotenv -e ./.env -e ../../.env -- next build",

--- a/packages/bot-engine/whatsapp/WhatsappComponentFlow/executeWhatsappFlow.ts
+++ b/packages/bot-engine/whatsapp/WhatsappComponentFlow/executeWhatsappFlow.ts
@@ -15,7 +15,7 @@ import {
   WhatsappSocketSendingMessage,
   convertMessageToWhatsappComponent,
 } from './convertMessageToWhatsappComponent'
-import { sendSocketWhatsappMessage } from './sendWhatsappSocketMessage'
+import { sendMessageWhatsappComponent } from './sendMessageWhatsappComponent'
 
 type Props = {
   state: SessionState
@@ -62,7 +62,7 @@ export async function executeWhatsappFlow({
     const whatsAppMessage = convertMessageToWhatsappComponent(message)
     if (isNotDefined(whatsAppMessage)) continue
     try {
-      await sendSocketWhatsappMessage(state.whatsappComponent?.clientId, {
+      await sendMessageWhatsappComponent(state.whatsappComponent?.clientId, {
         message: whatsAppMessage,
         phones: [state.whatsappComponent.phone],
         sessionId: state.sessionId as unknown as string,
@@ -112,7 +112,7 @@ export async function executeWhatsappFlow({
             })
         if (typingDuration)
           await new Promise((resolve) => setTimeout(resolve, typingDuration))
-        await sendSocketWhatsappMessage(state.whatsappComponent?.clientId, {
+        await sendMessageWhatsappComponent(state.whatsappComponent?.clientId, {
           message,
           phones: [state.whatsappComponent.phone],
           sessionId: state.sessionId as unknown as string,

--- a/packages/bot-engine/whatsapp/WhatsappComponentFlow/sendMessageWhatsappComponent.ts
+++ b/packages/bot-engine/whatsapp/WhatsappComponentFlow/sendMessageWhatsappComponent.ts
@@ -64,7 +64,7 @@ export const sendMessageWhatsappComponent = async (
       message,
     })
   } catch (err: any) {
-    if (err.response.status === 401) {
+    if (err?.response?.status === 401) {
       if (!state?.typebotsQueue[0]?.typebot?.id) return
       const typebot = await getMembersByTypebotSession(
         state.typebotsQueue[0].typebot.id

--- a/packages/bot-engine/whatsapp/WhatsappComponentFlow/sendMessageWhatsappComponent.ts
+++ b/packages/bot-engine/whatsapp/WhatsappComponentFlow/sendMessageWhatsappComponent.ts
@@ -1,0 +1,92 @@
+import { SessionState } from '@typebot.io/schemas'
+import { WhatsappSocketSendingMessage } from './convertMessageToWhatsappComponent'
+import axios from 'axios'
+import { env } from '@typebot.io/env'
+import prisma from '@typebot.io/lib/prisma'
+import { TRPCError } from '@trpc/server'
+
+type SendMessagePayload = {
+  phones: string[]
+  message: WhatsappSocketSendingMessage
+  sessionId: string
+  state?: SessionState
+}
+
+const sendNotificationToMember = async (
+  member: { id: string; name: string },
+  typebotName: string
+) => {
+  await axios.post(`${env.NEXT_PUBLIC_FUNNELHUB_URL}/api/v1/notifications`, {
+    userId: member.id,
+    title: 'Sessão do whatsapp expirada',
+    description: `Olá ${member.name}, notamos que a sessão do whatsapp no typebot com nome ${typebotName} foi expirado, por favor, leia o qrcode novamente para evitar problemas com seu fluxo.`,
+    notificationDeliveryType: ['email'],
+    type: 'ALERT',
+  })
+}
+
+const getMembersByTypebotSession = async (typebotId: string) => {
+  const typebot = await prisma.typebot.findFirst({
+    where: { id: typebotId },
+    select: {
+      name: true,
+      workspace: {
+        select: {
+          members: {
+            select: {
+              role: true,
+              user: {
+                select: {
+                  email: true,
+                  name: true,
+                  id: true,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  })
+  if (!typebotId) throw new Error('Typebot not found')
+  return typebot
+}
+
+export const sendMessageWhatsappComponent = async (
+  clientId: string,
+  { message, phones, sessionId, state }: SendMessagePayload
+) => {
+  try {
+    await axios.post(`${env.WHATSAPP_SERVER}/send-message`, {
+      sessionId,
+      clientId,
+      phoneNumber: phones[0],
+      message,
+    })
+  } catch (err: any) {
+    if (err.response.status === 401) {
+      if (!state?.typebotsQueue[0]?.typebot?.id) return
+      const typebot = await getMembersByTypebotSession(
+        state.typebotsQueue[0].typebot.id
+      )
+      if (!typebot) return
+      await Promise.all(
+        typebot.workspace.members.map(async (member) => {
+          await sendNotificationToMember(
+            {
+              id: member.user.id as unknown as string,
+              name: member.user.name as unknown as string,
+            },
+            typebot.name
+          )
+        })
+      )
+      throw new TRPCError({
+        code: 'BAD_REQUEST',
+        message:
+          'Sessão expirada, por favor configure novamente o qr code do seu whatsapp',
+      })
+    }
+    throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR' })
+  }
+}


### PR DESCRIPTION
# Enviar requisição ao invés de websocket

- Devemos realizar uma requisição http ao invés de websocket para o serviço de whatsapp
- Isso nos dará vários benefícios, pois não precisaremos mais de conexões websocket desnecessárias a todo momento
- A conexão websocket se derá apenas nos momentos de geração de qr code